### PR TITLE
Added exception handling for periodic callback errors 

### DIFF
--- a/py/desinightlog/report.py
+++ b/py/desinightlog/report.py
@@ -482,8 +482,12 @@ class Report(Layout):
             if 'lastPeriodicCallbackError' in locals():
                 if self.lastPeriodicCallbackError == e:
                     print('same error {0}'.format(e))
-            self.lastPeriodicCallbackError = e
-            raise(e)
+                else:
+                    self.lastPeriodicCallbackError = e
+                    raise(e)
+            else:
+                self.lastPeriodicCallbackError = e
+                raise(e)
         path = self.DESI_Log.nightlog_html 
         nl_file = open(path,'r')
         nl_txt = ''

--- a/py/desinightlog/report.py
+++ b/py/desinightlog/report.py
@@ -474,7 +474,15 @@ class Report(Layout):
         """Updates NightLog on Current NightLog Page. Updated every 30 seconds
         """
         now = datetime.datetime.now()
-        self.DESI_Log.finish_the_night()
+        try:
+            self.DESI_Log.finish_the_night()
+            if 'lastPeriodicCallbackError' in locals():
+                delattr(self, 'lastPeriodicCallbackError')
+        except Exception as e:
+            if 'lastPeriodicCallbackError' in locals():
+                if self.lastPeriodicCallbackError == e:
+                    print('same error {0}'.format(e))
+            self.lastPeriodicCallbackError = e
         path = self.DESI_Log.nightlog_html 
         nl_file = open(path,'r')
         nl_txt = ''

--- a/py/desinightlog/report.py
+++ b/py/desinightlog/report.py
@@ -483,6 +483,7 @@ class Report(Layout):
                 if self.lastPeriodicCallbackError == e:
                     print('same error {0}'.format(e))
             self.lastPeriodicCallbackError = e
+            raise(e)
         path = self.DESI_Log.nightlog_html 
         nl_file = open(path,'r')
         nl_txt = ''


### PR DESCRIPTION
to reduce log overloading.

Wrapped the "finish_the_night" call in "current_nl" to catch all exceptions, add them to a local variable, and not raise a new exception if it is the same as the old exception. Instead print a single line to indicate it's the same exception as before. 